### PR TITLE
Correct known_territory_subdivisions typespec and add test

### DIFF
--- a/lib/cldr/territory.ex
+++ b/lib/cldr/territory.ex
@@ -150,7 +150,7 @@ defmodule Cldr.Territory do
       "gbdal", "gbdby", "gbden", ...]}
   """
   @spec known_territory_subdivisions(atom_binary_tag(), Cldr.backend()) ::
-          {:ok, binary()} | {:error, error()}
+          {:ok, binary() | nil} | {:error, error()}
   def known_territory_subdivisions(territory_code, backend) do
     module = Module.concat(backend, Territory)
     module.known_territory_subdivisions(territory_code)

--- a/test/territory_test.exs
+++ b/test/territory_test.exs
@@ -1032,4 +1032,17 @@ defmodule Cldr.TerritoryTest do
     end
   end
 
+  describe "known_territory_subdivisions/2" do
+    test "with valid params" do
+      assert {:ok, ["usak", "usal" | _]} =
+               Territory.known_territory_subdivisions(:US, TestBackend.Cldr)
+    end
+
+    test "with invalid params" do
+      assert {:ok, nil} = Territory.known_territory_subdivisions(:EU, TestBackend.Cldr)
+
+      assert {:error, {Cldr.UnknownTerritoryError, "The territory :NOPE is unknown"}} =
+               Territory.known_territory_subdivisions(:NOPE, TestBackend.Cldr)
+    end
+  end
 end


### PR DESCRIPTION
`Territory.known_territory_subdivisions/2` may also return `{:ok, nil}`, this can cause dialyzer issues to applications calling this function.