### PR TITLE
Document need to configure `Cldr.Territory` as provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ then retrieve `ex_cldr_territories` from [hex](https://hex.pm/packages/ex_cldr_t
     mix deps.get
     mix deps.compile
 
+In order to use this library, a backend module for `ex_cldr` must be defined.  This is described in full in the `ex_cldr` [readme](https://hexdocs.pm/ex_cldr/readme.html#configuration).
+To get started, define a backend module in your project as follows:
+
+```elixir
+defmodule MyApp.Cldr do
+  use Cldr,
+    locales: [:en],
+    providers: [Cldr.Territory]
+end
+```
+
 ## LICENSE
 
 (The MIT License)


### PR DESCRIPTION
After a conversation with @kipcole9 we noticed that the docs could be improved by adding a hint of how you'd add the `Cldr.Territory` provider to the Cldr configuration.

Shamelessly stole the example from another Cldr readme.

Hope this makes sense.