### PR TITLE
Fix typespec for Territory.known_territory_subdivisions/2

### DIFF
--- a/lib/cldr/territory.ex
+++ b/lib/cldr/territory.ex
@@ -150,7 +150,7 @@ defmodule Cldr.Territory do
       "gbdal", "gbdby", "gbden", ...]}
   """
   @spec known_territory_subdivisions(atom_binary_tag(), Cldr.backend()) ::
-          {:ok, binary() | nil} | {:error, error()}
+          {:ok, list(binary()) | nil} | {:error, error()}
   def known_territory_subdivisions(territory_code, backend) do
     module = Module.concat(backend, Territory)
     module.known_territory_subdivisions(territory_code)


### PR DESCRIPTION
The typespec of `Territories.known_territory_subdivisions/2` is incorrect and is causing dialyzer errors.

As seen it the docs example, it returns a list of strings, not a string.

```elixir
Cldr.Territory.known_territory_subdivisions(:GB, TestBackend.Cldr)
      {:ok, ["gbabc", "gbabd", "gbabe", ...]}
 ```