### PR TITLE
Solve ambiguity by adding parentheses

### DIFF
--- a/lib/cldr/backend.ex
+++ b/lib/cldr/backend.ex
@@ -384,7 +384,7 @@ defmodule Cldr.Territory.Backend do
         def from_language_tag!(%LanguageTag{cldr_locale_name: cldr_locale_name, territory: territory}, [style: style]) do
           from_territory_code!(territory, [locale: cldr_locale_name, style: style])
         end
-        def from_language_tag!(tag, _options), do: raise Cldr.UnknownLanguageTagError, "The tag #{inspect tag} is not a valid `LanguageTag.t`"
+        def from_language_tag!(tag, _options), do: raise(Cldr.UnknownLanguageTagError, "The tag #{inspect tag} is not a valid `LanguageTag.t`")
 
         @doc """
         Translate a localized string from one locale to another.

--- a/lib/cldr/territory.ex
+++ b/lib/cldr/territory.ex
@@ -1131,7 +1131,7 @@ defmodule Cldr.Territory do
   end
   defp map_binary(result) when is_atom(result), do: to_string(result)
 
-  defp map_binary!({:error, {exception, reason}}), do: raise exception, reason
+  defp map_binary!({:error, {exception, reason}}), do: raise(exception, reason)
   defp map_binary!({:ok, result}), do: map_binary(result)
 
   defp map_charlist({:error, reason}), do: {:error, reason}
@@ -1141,7 +1141,7 @@ defmodule Cldr.Territory do
   end
   defp map_charlist(result) when is_atom(result), do: to_charlist(result)
 
-  defp map_charlist!({:error, {exception, reason}}), do: raise exception, reason
+  defp map_charlist!({:error, {exception, reason}}), do: raise(exception, reason)
   defp map_charlist!({:ok, result}), do: map_charlist(result)
 
   @doc false


### PR DESCRIPTION
Fixes those warnings…

```
==> ex_cldr_territories
Compiling 3 files (.ex)
warning: missing parentheses for expression following "do:" keyword. Parentheses are required to solve ambiguity inside keywords.

This error happens when you have function calls without parentheses inside keywords. For example:

    function(arg, one: nested_call a, b, c)
    function(arg, one: if expr, do: :this, else: :that)

In the examples above, we don't know if the arguments "b" and "c" apply to the function "function" or "nested_call". Or if the keywords "do" and "else" apply to the function "function" or "if". You can solve this by explicitly adding parentheses:

    function(arg, one: if(expr, do: :this, else: :that))
    function(arg, one: nested_call(a, b, c))

Ambiguity found at:
  lib/cldr/territory.ex:1134

warning: missing parentheses for expression following "do:" keyword. Parentheses are required to solve ambiguity inside keywords.

This error happens when you have function calls without parentheses inside keywords. For example:

    function(arg, one: nested_call a, b, c)
    function(arg, one: if expr, do: :this, else: :that)

In the examples above, we don't know if the arguments "b" and "c" apply to the function "function" or "nested_call". Or if the keywords "do" and "else" apply to the function "function" or "if". You can solve this by explicitly adding parentheses:

    function(arg, one: if(expr, do: :this, else: :that))
    function(arg, one: nested_call(a, b, c))

Ambiguity found at:
  lib/cldr/backend.ex:387

warning: missing parentheses for expression following "do:" keyword. Parentheses are required to solve ambiguity inside keywords.

This error happens when you have function calls without parentheses inside keywords. For example:

    function(arg, one: nested_call a, b, c)
    function(arg, one: if expr, do: :this, else: :that)

In the examples above, we don't know if the arguments "b" and "c" apply to the function "function" or "nested_call". Or if the keywords "do" and "else" apply to the function "function" or "if". You can solve this by explicitly adding parentheses:

    function(arg, one: if(expr, do: :this, else: :that))
    function(arg, one: nested_call(a, b, c))

Ambiguity found at:
  lib/cldr/territory.ex:1144

Generated ex_cldr_territories app
```