### PR TITLE
Resolve subdivision aliases

### DIFF
--- a/lib/cldr/territory.ex
+++ b/lib/cldr/territory.ex
@@ -262,6 +262,10 @@ defmodule Cldr.Territory do
     * `locale` is any configured locale. See `Cldr.known_locale_names/1`.
       The default is `Cldr.get_locale/1`
 
+    * `style` is one of those returned by `Cldr.Territory.available_styles/0`.
+      The current styles are `:short`, `:standard` and `:variant`.
+      The default is `:standard`
+
   ## Example
 
       iex> #{inspect __MODULE__}.from_subdivision_code("gbcma", TestBackend.Cldr, locale: "en")
@@ -271,7 +275,7 @@ defmodule Cldr.Territory do
       {:ok, "Kumbria"}
 
       iex> #{inspect __MODULE__}.from_subdivision_code("gbcma", TestBackend.Cldr, locale: "bs")
-      {:error, {Cldr.UnknownSubdivisionError, "The locale :bs has no translation for :gbcma."}}
+      {:error, {Cldr.UnknownSubdivisionError, "No subdivision translation for :gbcma could be found in locale :bs"}}
 
       iex> #{inspect __MODULE__}.from_subdivision_code("invalid", TestBackend.Cldr, locale: "en")
       {:error, {Cldr.UnknownTerritoryError, "The territory \\"invalid\\" is unknown"}}
@@ -283,15 +287,9 @@ defmodule Cldr.Territory do
       {:error, {Cldr.InvalidLanguageError, "The language \\"zzz\\" is invalid"}}
 
   """
-  @spec from_subdivision_code(binary(), Cldr.backend(), [locale: binary_tag()]) ::
-          {:ok, binary()} | {:error, error()}
-  def from_subdivision_code(
-        subdivision_code,
-        backend,
-        options \\ [locale: Cldr.get_locale()]
-      ) do
-    module = Module.concat(backend, Territory)
-    module.from_subdivision_code(subdivision_code, options)
+  @spec from_subdivision_code(atom_binary_tag(), Cldr.backend(), options) :: {:ok, String.t()} | {:error, error()}
+  def from_subdivision_code(subdivision_code, backend, options \\ []) do
+    Module.concat(backend, Territory).from_subdivision_code(subdivision_code, Keyword.merge([locale: Cldr.get_locale(), style: :standard], options))
   end
 
   @doc """
@@ -327,15 +325,9 @@ defmodule Cldr.Territory do
       "Kumbria"
 
   """
-  @spec from_subdivision_code!(binary(), Cldr.backend(), [locale: binary_tag()]) ::
-          binary() | no_return()
-  def from_subdivision_code!(
-        territory_code,
-        backend,
-        options \\ [locale: Cldr.get_locale()]
-      ) do
-    module = Module.concat(backend, Territory)
-    module.from_subdivision_code!(territory_code, options)
+  @spec from_subdivision_code!(String.t(), Cldr.backend(), options()) :: String.t() | no_return()
+  def from_subdivision_code!(territory_code, backend, options \\ []) do
+    Module.concat(backend, Territory).from_subdivision_code!(territory_code, Keyword.merge([locale: Cldr.get_locale(), style: :standard], options))
   end
 
   @doc """
@@ -438,7 +430,7 @@ defmodule Cldr.Territory do
       {:ok, "Kumbria"}
 
       iex> #{inspect __MODULE__}.translate_subdivision("Cumbria", "en", TestBackend.Cldr, "bs")
-      {:error, {Cldr.UnknownSubdivisionError, "The locale :bs has no translation for :gbcma."}}
+      {:error, {Cldr.UnknownSubdivisionError, "No subdivision translation for :gbcma could be found in locale :bs"}}
 
       iex> #{inspect __MODULE__}.translate_subdivision("Cumbria", :zzz, TestBackend.Cldr)
       {:error, {Cldr.InvalidLanguageError, "The language \\"zzz\\" is invalid"}}
@@ -447,11 +439,9 @@ defmodule Cldr.Territory do
       {:error, {Cldr.InvalidLanguageError, "The language \\"zzz\\" is invalid"}}
 
   """
-  @spec translate_subdivision(binary(), binary_tag(), Cldr.backend(), binary_tag()) ::
-          {:ok, binary()} | {:error, error()}
-  def translate_subdivision(localized_string, from_locale, backend, to_locale \\ Cldr.get_locale()) do
-    module = Module.concat(backend, Territory)
-    module.translate_subdivision(localized_string, from_locale, to_locale)
+  @spec translate_subdivision(String.t(), binary_tag(), Cldr.backend(), binary_tag()) :: {:ok, String.t()} | {:error, error()}
+  def translate_subdivision(localized_string, from_locale, backend \\ Cldr.default_backend!(), to_locale \\ Cldr.get_locale(), style \\ :standard) do
+    Module.concat(backend, Territory).translate_subdivision(localized_string, from_locale, to_locale, style)
   end
 
   @doc """
@@ -499,11 +489,9 @@ defmodule Cldr.Territory do
       ** (Cldr.UnknownSubdivisionError) The locale "bs" has no translation for "gbcma".
 
   """
-  @spec translate_subdivision!(binary(), binary_tag(), Cldr.backend(), binary_tag()) ::
-          binary() | no_return()
-  def translate_subdivision!(localized_string, from_locale, backend, to_locale \\ Cldr.get_locale()) do
-    module = Module.concat(backend, Territory)
-    module.translate_subdivision!(localized_string, from_locale, to_locale)
+  @spec translate_subdivision!(String.t(), binary_tag(), Cldr.backend(), binary_tag()) :: String.t() | no_return()
+  def translate_subdivision!(localized_string, from_locale, backend \\ Cldr.default_backend!(), to_locale \\ Cldr.get_locale(), style \\ :standard) do
+    Module.concat(backend, Territory).translate_subdivision!(localized_string, from_locale, to_locale, style)
   end
 
   @doc """

--- a/lib/cldr/territory.ex
+++ b/lib/cldr/territory.ex
@@ -19,6 +19,10 @@ defmodule Cldr.Territory do
   @styles [:short, :standard, :variant]
   @territory_containment Cldr.Config.territory_containers()
   @territory_info Cldr.Config.territories()
+  @subdivision_aliases  Map.new(Map.fetch!(Cldr.Config.aliases(), :subdivision), fn
+                          {k, <<v::binary>>} -> {:"#{k}", :"#{v}"}
+                          {k, v} -> {:"#{k}", Enum.map(v, &:"#{&1}")}
+                        end)
 
   @doc """
   Returns a list of available styles.
@@ -30,6 +34,17 @@ defmodule Cldr.Territory do
   """
   @spec available_styles() :: [styles()]
   def available_styles(), do: @styles
+
+  @doc """
+  Returns a map of available subdivision aliases.
+
+  ## Example
+
+      iex#> Cldr.Territory.subdivision_aliases()
+      %{:uspr => :PR}
+  """
+  @spec subdivision_aliases() :: map()
+  def subdivision_aliases(), do: @subdivision_aliases
 
   @doc """
   Returns the available territories for a given locale.

--- a/test/territory_test.exs
+++ b/test/territory_test.exs
@@ -161,6 +161,8 @@ defmodule Cldr.TerritoryTest do
   describe "from_subdivision_code/1" do
     test "with valid params" do
       assert {:ok, "Ontario"} == Territory.from_subdivision_code("CAON", TestBackend.Cldr, [locale: "en"])
+      assert {:ok, "Hebei"} == Territory.from_subdivision_code("CN13", TestBackend.Cldr, [locale: "en"])
+      assert {:ok, "Puerto Rico"} == Territory.from_subdivision_code("USPR", TestBackend.Cldr, [locale: "en"])
       assert {:ok, "אונטריו"} == Territory.from_subdivision_code("caon", TestBackend.Cldr, [locale: "he"])
     end
 

--- a/test/territory_test.exs
+++ b/test/territory_test.exs
@@ -167,7 +167,7 @@ defmodule Cldr.TerritoryTest do
     end
 
     test "with invalid params" do
-      assert {:error, {Cldr.UnknownSubdivisionError, "The locale :\"en-001\" has no subdivisions."}} == Territory.from_subdivision_code("CAON", TestBackend.Cldr)
+      assert {:error, {Cldr.UnknownSubdivisionError, "No subdivision translation for :caon could be found in locale :\"en-001\""}} == Territory.from_subdivision_code("CAON", TestBackend.Cldr)
       assert {:error, {Cldr.UnknownTerritoryError, "The territory :ZZ is unknown"}} == Territory.from_subdivision_code(:ZZ, TestBackend.Cldr)
       assert {:error, {Cldr.InvalidLanguageError, "The language \"zzz\" is invalid"}} == Territory.from_subdivision_code("CAON", TestBackend.Cldr, [locale: "zzz"])
       assert {:error, {Cldr.InvalidLanguageError, "The language \"zzz\" is invalid"}} == Territory.from_subdivision_code("CAON", TestBackend.Cldr, [locale: :zzz])
@@ -181,7 +181,7 @@ defmodule Cldr.TerritoryTest do
     end
 
     test "with invalid params" do
-      assert_raise Cldr.UnknownSubdivisionError, "The locale :\"en-001\" has no subdivisions.", fn ->
+      assert_raise Cldr.UnknownSubdivisionError, "No subdivision translation for :caon could be found in locale :\"en-001\"", fn ->
         Territory.from_subdivision_code!("CAON", TestBackend.Cldr)
       end
       assert_raise Cldr.UnknownTerritoryError, "The territory :ZZ is unknown", fn ->
@@ -297,7 +297,7 @@ defmodule Cldr.TerritoryTest do
     end
 
     test "with invalid params" do
-      assert {:error, {Cldr.UnknownSubdivisionError, "The locale :\"en-001\" has no subdivisions."}} == Territory.translate_subdivision("Ontario", "en-001", TestBackend.Cldr, "bs")
+      assert {:error, {Cldr.UnknownSubdivisionError, "No subdivision translation for \"Ontario\" could be found in locale :\"en-001\""}} == Territory.translate_subdivision("Ontario", "en-001", TestBackend.Cldr, "bs")
       assert {:error, {Cldr.InvalidLanguageError, "The language \"zzz\" is invalid"}} == Territory.translate_subdivision("CAON", "zzz", TestBackend.Cldr, "bs")
       assert {:error, {Cldr.InvalidLanguageError, "The language \"zzz\" is invalid"}} == Territory.translate_subdivision("CAON", "en", TestBackend.Cldr, "zzz")
       assert {:error, {Cldr.InvalidLanguageError, "The language \"zzz\" is invalid"}} == Territory.translate_subdivision("CAON", :zzz, TestBackend.Cldr, "bs")
@@ -314,7 +314,7 @@ defmodule Cldr.TerritoryTest do
     end
 
     test "with invalid params" do
-      assert_raise Cldr.UnknownSubdivisionError, "The locale :\"en-001\" has no subdivisions.", fn ->
+      assert_raise Cldr.UnknownSubdivisionError, "No subdivision translation for \"Ontario\" could be found in locale :\"en-001\"", fn ->
         Territory.translate_subdivision!("Ontario", "en-001", TestBackend.Cldr, "bs")
       end
       assert_raise Cldr.InvalidLanguageError, "The language \"zzz\" is invalid", fn ->


### PR DESCRIPTION
This PR closes #33 by resolving subdivision aliases.


Some subdivision aliases to a territory e.g. Puerto Rico, which can have different styles for their translation, ~currently only the standard style is returned in those cases~.