### PR TITLE
Subdivision alias may be an ISO3166 region

### DIFF
--- a/lib/cldr/territory.ex
+++ b/lib/cldr/territory.ex
@@ -13,6 +13,7 @@ defmodule Cldr.Territory do
   @territory_info Cldr.Config.territories()
   @subdivision_aliases Map.new(Map.fetch!(Cldr.Config.aliases(), :subdivision), fn
     {k, <<v::binary>>} -> {:"#{k}", :"#{v}"}
+    {k, v} when is_atom(v) -> {:"#{k}", v}
     {k, v} -> {:"#{k}", Enum.map(v, &:"#{&1}")}
   end)
 


### PR DESCRIPTION
In ex_cldr 2.38.0, subdivision aliases that are
themselves a region (as defined by ISO 3166) will
have their alias normalized to the upcased atom
format of a territory code.

There should be no incompatibility with the existing
releases of `ex_cldr_territories` and all tests are
passing without modification.
