### PR TITLE
Fix spec for `known_territory_subdivision`

### DIFF
--- a/lib/cldr/backend.ex
+++ b/lib/cldr/backend.ex
@@ -171,12 +171,15 @@ defmodule Cldr.Territory.Backend do
             "gbcma", "gbcmd", "gbcmn", "gbcon", "gbcov", "gbcrf", "gbcry", "gbcwy",
             "gbdal", "gbdby", "gbden", ...]}
 
+            => #{inspect __MODULE__}.known_territory_subdivisions(:AI)
+            {:ok, nil}
+
             iex> #{inspect __MODULE__}.known_territory_subdivisions(:ZZZ)
             {:error, {Cldr.UnknownTerritoryError, "The territory :ZZZ is unknown"}}
 
         """
         @doc since: "2.2.0"
-        @spec known_territory_subdivisions(atom() | String.t() | LanguageTag.t()) :: {:ok, String.t()} | {:error, {module(), String.t()}}
+        @spec known_territory_subdivisions(atom() | String.t() | LanguageTag.t()) :: {:ok, [String.t()] | nil} | {:error, {module(), String.t()}}
         def known_territory_subdivisions(territory_code) do
           case Cldr.validate_territory(territory_code) do
             {:error, reason}      -> {:error, reason}

--- a/lib/cldr/territory.ex
+++ b/lib/cldr/territory.ex
@@ -152,7 +152,7 @@ defmodule Cldr.Territory do
       "gbdal", "gbdby", "gbden", ...]}
   """
   @doc since: "2.2.0"
-  @spec known_territory_subdivisions(atom() | String.t() | LanguageTag.t(), Cldr.backend()) :: {:ok, [String.t()]} | {:error, {module(), String.t()}}
+  @spec known_territory_subdivisions(atom() | String.t() | LanguageTag.t(), Cldr.backend()) :: {:ok, [String.t()] | nil} | {:error, {module(), String.t()}}
   def known_territory_subdivisions(territory_code, backend), do: Module.concat(backend, Territory).known_territory_subdivisions(territory_code)
 
   @doc """


### PR DESCRIPTION
`{:ok, nil}` is a valid response and not covered by the existing spec. Here I update the spec to account for this case.

There's an argument that maybe the library should return `{:ok, []}` when there are no known subdivisions for a valid territory. But as the `{:ok, nil}` was already the tested result I went with just updating the spec.

Reproduce: 

```elixir
iex(8)> Cldr.Territory.known_territory_subdivisions(:AI)
{:ok, nil}
```